### PR TITLE
Allow multiple editors on single page

### DIFF
--- a/lib/json-editor.vue
+++ b/lib/json-editor.vue
@@ -111,7 +111,7 @@ export default {
         onBlur,
       };
       this.editor = new JsonEditor(
-        document.querySelector(".json-editor-vue"),
+        this.$refs.jsonEditorVue,
         finalOptions,
         this.json
       );
@@ -130,7 +130,7 @@ export default {
 
 <template>
   <div class="container" :class="{ 'full-screen-container': isFullScreen }">
-    <div class="json-editor-vue" />
+    <div ref="jsonEditorVue" class="json-editor-vue" />
     <div
       class="full-screen"
       :class="{


### PR DESCRIPTION
The use of a queryselector always matches the first occurance of an HTML object with that classname, via $refs you can target this one specifically